### PR TITLE
feat: use native ARM runners instead of QEMU for multi-arch build

### DIFF
--- a/.github/workflows/docker-image-arm.yml
+++ b/.github/workflows/docker-image-arm.yml
@@ -1,36 +1,28 @@
-name: Docker Image CI ARM - Tools ARM
+# DEPRECATED: This workflow has been replaced by docker-image.yml
+# which uses native ubuntu-24.04-arm runners instead of self-hosted ARM runners.
+# The Dockerfile-arm (FROM arm64v8/alpine) is superseded by the standard
+# Dockerfile (FROM alpine) which builds natively for linux/arm64.
+#
+# This file is kept for reference only and will not run.
+# See docker-image.yml for the current multi-arch build configuration.
+name: '[DEPRECATED] Docker Image CI ARM - Tools ARM'
 
 on:
-  workflow_dispatch: # Agrega esta entrada para habilitar la ejecución manual
-    branches: [ "master", "main" ] # Opcional: restringe las ramas donde se puede ejecutar
+  workflow_dispatch:
+    inputs:
+      _notice:
+        description: 'This workflow is deprecated. Use docker-image.yml instead.'
+        required: false
+        type: string
 
 jobs:
-
-  build_push_image:
-
-    runs-on: self-hosted
-
+  deprecated-notice:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6.0.2
-      name: Download codigo from repo
-      
-    - name: Docker Login
-      uses: docker/login-action@v4.0.0
-      with:
-        registry: docker.io
-        username: ${{ secrets.USER_HUB }}
-        password: ${{ secrets.PASS_HUB }}
-        
-    
-    - name: Build and push the Docker image latest
-      run: |
-        docker build . --file Dockerfile-arm --tag neytor/tools:arm && 
-        docker image ls && docker push neytor/tools:arm
+      - name: Notice
+        run: |
+          echo '::warning::This workflow is deprecated.'
+          echo '::warning::ARM builds are now handled natively by docker-image.yml'
+          echo '::warning::using ubuntu-24.04-arm runners. Do not use this file.'
 
-    # - name: Build and push the Docker image with tag
-    #   run: |
-    #     docker build . --file Dockerfile --tag neytor/tools:arm.v2 && \
-    #     docker image ls && docker push neytor/tools:arm.v2
-      
-    
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,35 +1,126 @@
-name: Docker Image CI - Tools
+name: Docker Multi-Arch CI - Tools
 
 on:
   push:
     branches: [ "master", "main" ]
   pull_request:
     branches: [ "master", "main" ]
-  workflow_dispatch: # Agrega esta entrada para habilitar la ejecución manual
-    branches: [ "master", "main" ] # Opcional: restringe las ramas donde se puede ejecutar
+  workflow_dispatch:
+    inputs:
+      force_build:
+        description: 'Force build even if no changes'
+        required: false
+        type: choice
+        default: 'false'
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
 
-  build_push_image_tools:
+  # ── PR-only build (no push) ───────────────────────────────────────────────────
+  build-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: false
+
+  # ── Phase 1: build per-arch on native runners ─────────────────────────────────
+  build:
+    if: github.event_name != 'pull_request'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Docker Login
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.USER_HUB }}
+          password: ${{ secrets.PASS_HUB }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7.0.0
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          outputs: type=image,name=neytor/tools,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest artifact
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: digest-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── Phase 2: merge digests into multi-arch manifest ──────────────────────────
+  build-and-push:
+    needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6.0.2
-      name: Download codigo from repo
-      
-    - name: Docker Login
-      uses: docker/login-action@v4.0.0
-      with:
-        registry: docker.io
-        username: ${{ secrets.USER_HUB }}
-        password: ${{ secrets.PASS_HUB }}
-        
-    
-    - name: Build and push the Docker image latest
-      run: |
-        docker build . --file Dockerfile --tag neytor/tools && 
-        docker image ls && docker push neytor/tools
-      
-    
+      - name: Download digests
+        uses: actions/download-artifact@v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Docker Login
+        uses: docker/login-action@v4.0.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.USER_HUB }}
+          password: ${{ secrets.PASS_HUB }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t neytor/tools:latest \
+            $(printf 'neytor/tools@sha256:%s ' $(ls /tmp/digests))
+
 


### PR DESCRIPTION
Replace single-arch amd64 job + self-hosted ARM (Dockerfile-arm) with unified matrix using native ubuntu-24.04-arm runners. Both arches now use the standard Dockerfile (FROM alpine). Deprecate docker-image-arm.yml.