### PR TITLE
feat: Samba multi-arch CI workflow + README rewrite

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,14 +1,20 @@
-name: Docker Multi-Arch CI - Tools
+name: Docker Multi-Arch CI - Samba
 
 on:
-  push:
-    branches: [ "master", "main" ]
-  pull_request:
-    branches: [ "master", "main" ]
+  schedule:
+    - cron: '0 8 * * 1'  # Every Monday 08:00 UTC
   workflow_dispatch:
     inputs:
       force_build:
-        description: 'Force build even if no changes'
+        description: 'Force build even if Samba version unchanged'
+        required: false
+        type: choice
+        default: 'false'
+        options:
+          - 'true'
+          - 'false'
+      skip_release:
+        description: 'Build and push Docker image but skip GitHub Release creation'
         required: false
         type: choice
         default: 'false'
@@ -16,37 +22,57 @@ on:
           - 'true'
           - 'false'
 
-jobs:
+permissions:
+  contents: write
 
-  # ── PR-only build (no push) ───────────────────────────────────────────────────
-  build-pr:
-    if: github.event_name == 'pull_request'
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-latest
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
+jobs:
+  # ── Phase 1: detect whether a new Samba version is available ─────────────────
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.samba_version.outputs.version }}
+      should_build: ${{ steps.compare.outputs.should_build }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - name: Get latest Samba version from Alpine
+        id: samba_version
+        run: |
+          SAMBA_VERSION=$(docker run --rm alpine:latest sh -c \
+            "apk update > /dev/null 2>&1 && apk list samba 2>/dev/null | grep '^samba-' | head -1 | sed 's/samba-\([^ ]*\).*/\1/'")
+          echo "version=$SAMBA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Samba version in Alpine: $SAMBA_VERSION"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+      - name: Get latest GitHub release tag
+        id: get_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST=$(gh release list \
+            --repo ${{ github.repository }} \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName // ""')
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "Latest release: $LATEST"
 
-      - name: Build (no push)
-        uses: docker/build-push-action@v7.0.0
-        with:
-          context: .
-          platforms: ${{ matrix.platform }}
-          push: false
+      - name: Decide whether to build
+        id: compare
+        run: |
+          CURRENT="v${{ steps.samba_version.outputs.version }}"
+          LATEST="${{ steps.get_release.outputs.latest }}"
+          FORCE="${{ github.event.inputs.force_build }}"
+          if [[ "$CURRENT" != "$LATEST" || "$FORCE" == "true" ]]; then
+            echo "should_build=true"  >> "$GITHUB_OUTPUT"
+            echo "Build needed: current=$CURRENT, latest_release=$LATEST, force=$FORCE"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "No new version — skipping build."
+          fi
 
-  # ── Phase 1: build per-arch on native runners ─────────────────────────────────
+  # ── Phase 2: build per-arch on native runners (no QEMU) ──────────────────────
   build:
-    if: github.event_name != 'pull_request'
+    needs: check-version
+    if: needs.check-version.outputs.should_build == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -66,7 +92,6 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v4.0.0
         with:
-          registry: docker.io
           username: ${{ secrets.USER_HUB }}
           password: ${{ secrets.PASS_HUB }}
 
@@ -75,9 +100,10 @@ jobs:
         uses: docker/build-push-action@v7.0.0
         with:
           context: .
+          file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          outputs: type=image,name=neytor/tools,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=neytor/samba,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -93,10 +119,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # ── Phase 2: merge digests into multi-arch manifest ──────────────────────────
+  # ── Phase 3: merge digests into multi-arch manifest ──────────────────────────
   build-and-push:
-    needs: build
-    if: github.event_name != 'pull_request'
+    needs: [check-version, build]
+    if: needs.check-version.outputs.should_build == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -113,14 +139,91 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v4.0.0
         with:
-          registry: docker.io
           username: ${{ secrets.USER_HUB }}
           password: ${{ secrets.PASS_HUB }}
 
       - name: Create and push multi-arch manifest
         run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
           docker buildx imagetools create \
-            -t neytor/tools:latest \
-            $(printf 'neytor/tools@sha256:%s ' $(ls /tmp/digests))
+            -t neytor/samba:latest \
+            -t neytor/samba:${VERSION} \
+            $(printf 'neytor/samba@sha256:%s ' $(ls /tmp/digests))
 
+  # ── Phase 4: GitHub Release with changelog ────────────────────────────────────
+  release:
+    needs: [check-version, build-and-push]
+    if: needs.check-version.outputs.should_build == 'true' && github.event.inputs.skip_release != 'true'
+    runs-on: ubuntu-latest
 
+    steps:
+      - name: Check if release already exists
+        id: check_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTS=$(gh release view "v${{ needs.check-version.outputs.version }}" \
+            --repo ${{ github.repository }} 2>/dev/null && echo "true" || echo "false")
+          echo "exists=$EXISTS" >> "$GITHUB_OUTPUT"
+
+      - name: Get Samba release notes
+        id: changelog
+        run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
+          SAMBA_BASE=$(echo "$VERSION" | sed 's/-r[0-9]*//')
+          URL="https://www.samba.org/samba/history/samba-${SAMBA_BASE}.html"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "base_version=$SAMBA_BASE" >> "$GITHUB_OUTPUT"
+          NOTES=$(curl -sf "$URL" 2>/dev/null | \
+            sed -n '/Changes since/,/<\/pre>/p' | \
+            sed 's/<[^>]*>//g' | \
+            sed '/^$/d' | \
+            head -60 || echo "No release notes found.")
+          echo "$NOTES" > /tmp/samba_changelog.txt
+
+      - name: Create GitHub Release
+        if: steps.check_release.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.check-version.outputs.version }}"
+          VERSION="${{ needs.check-version.outputs.version }}"
+          CHANGELOG=$(cat /tmp/samba_changelog.txt)
+          NOTES_URL="${{ steps.changelog.outputs.url }}"
+
+          cat > /tmp/release-notes.md << NOTES
+          ## Samba ${VERSION} on Alpine Linux
+
+          ### Docker Images
+
+          \`\`\`bash
+          docker pull neytor/samba:latest
+          docker pull neytor/samba:${VERSION}
+          \`\`\`
+
+          ### Supported Architectures
+
+          | Architecture | Tag |
+          |---|---|
+          | linux/amd64 | \`latest\`, \`${VERSION}\` |
+          | linux/arm64 | \`latest\`, \`${VERSION}\` |
+
+          ### Samba Changelog
+
+          \`\`\`
+          ${CHANGELOG}
+          \`\`\`
+
+          > [Full release notes](${NOTES_URL})
+
+          ### Quick Start
+
+          \`\`\`bash
+          docker run -d --name samba -p 445:445 -v samba:/download neytor/samba
+          \`\`\`
+          NOTES
+
+          gh release create "$TAG" \
+            --repo ${{ github.repository }} \
+            --title "Samba $VERSION" \
+            --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -1,71 +1,103 @@
-Herramientas de troubleshooting
-======================
+<div align="center">
 
-# Referencia rápida
+# 🗂️ neytor/samba
 
--	**¿Objetivo de la imagen?**
--	**¿Cómo usar esta imagen?**
--	**Paquetes instalados**
--	**Arquitectura soportada**
+**Lightweight Samba server on Alpine Linux — multi-architecture Docker image**
 
-## ¿Objetivo de la imagen?
+[![Docker Pulls](https://img.shields.io/docker/pulls/neytor/samba?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/neytor/samba)
+[![Docker Image Size](https://img.shields.io/docker/image-size/neytor/samba/latest?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/neytor/samba)
+[![GitHub Stars](https://img.shields.io/github/stars/YonierGomez/tools?style=for-the-badge&logo=github&logoColor=white&color=181717)](https://github.com/YonierGomez/tools/stargazers)
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/YonierGomez/tools/docker-image.yml?style=for-the-badge&logo=githubactions&logoColor=white&label=CI)](https://github.com/YonierGomez/tools/actions)
+[![License](https://img.shields.io/github/license/YonierGomez/tools?style=for-the-badge&color=green)](LICENSE)
 
-La finalidad de esta imagen es realizar tareas de operación como lo son validar endpoints, puertos de escucha, dns, comandos aws cli, etc.
+---
 
-<img src="https://media.licdn.com/dms/image/D4D12AQGWWcGt57vcgw/article-cover_image-shrink_720_1280/0/1676661051336?e=2147483647&v=beta&t=DPSkA9tURy5fcnZhxhsKREwkgeeK-VZZu5ZzCfjRn-g" alt="tr" style="zoom:30%;" />
+### Built with
 
-## ¿Cómo usar esta imagen?
+![Alpine Linux](https://img.shields.io/badge/Alpine_Linux-0D597F?style=for-the-badge&logo=alpine-linux&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
+![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=for-the-badge&logo=github-actions&logoColor=white)
+![Samba](https://img.shields.io/badge/Samba-D32F2F?style=for-the-badge&logo=samba&logoColor=white)
 
-Puede hacer uso de docker cli o docker compose, crea un container y conectate a través de un `exec`
+</div>
 
+---
 
-### docker cli
+## Overview
 
-```console
-$ docker container run --rm -ti neytor/tools
+This image provides a minimal **Samba** (SMB/CIFS) server built on top of **Alpine Linux**. It is automatically rebuilt every Monday to track the latest Samba version available in the Alpine package registry, and published as a multi-architecture image.
+
+## Quick Start
+
+```bash
+docker run -d \
+  --name samba \
+  -p 445:445 \
+  -v samba:/download \
+  neytor/samba
 ```
 
-### docker-compose (recomendado)
+## Usage
+
+### Docker CLI
+
+```bash
+docker pull neytor/samba:latest
+docker run -d --name samba -p 445:445 -v samba:/download neytor/samba
+```
+
+### Docker Compose
 
 ```yaml
----
-version: '3'
 services:
-  tools:
-    container_name: tools_container
-    image: neytor/tools
-    stdin_open: true
-    tty: true
-    command: ash #OPCIONAL
-...
+  samba:
+    container_name: samba
+    image: neytor/samba:latest
+    ports:
+      - "445:445"
+    volumes:
+      - samba:/download
+    restart: unless-stopped
+
+volumes:
+  samba:
 ```
 
-## Paquetes instalados
+## Supported Architectures
 
-La arquitectura soportada es la siguiente:
+| Architecture | Tag |
+|---|---|
+| `linux/amd64` | `latest`, `<version>` |
+| `linux/arm64` | `latest`, `<version>` |
 
-| Paquete      | Disponible | 
-| ------------ | ---------- | 
-| awscli v2    | ✅         | 
-| bind-tools   | ✅         | 
-| curl         | ✅         |
-| bind-tools   | ✅         |
-| zip, unzip   | ✅         |
-| iproute2     | ✅         |
-| net-tools    | ✅         |
-| dnsutils     | ✅         |
-| vim          | ✅         |
+Both architectures are built natively (no QEMU emulation) using GitHub-hosted runners.
 
-## Arquitectura soportada
+## CI / CD Pipeline
 
-La arquitectura soportada es la siguiente:
+The workflow runs automatically every Monday at 08:00 UTC and follows four stages:
 
-| Arquitectura | Disponible | Tag descarga                 |
-| ------------ | ---------- | ---------------------------- |
-| x86-64       | ✅          | docker pull neytor/tools    |
-| arm64        | ✅          | docker pull neytor/tools:arm
+| Phase | Job | Description |
+|---|---|---|
+| 1 | `check-version` | Detects the latest Samba version from Alpine and compares with the last GitHub Release |
+| 2 | `build` | Builds per-arch images on native runners and pushes by digest |
+| 3 | `build-and-push` | Merges digests into a single multi-arch manifest |
+| 4 | `release` | Creates a GitHub Release with changelog fetched from samba.org |
 
-[![Try in PWD](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/docker-library/docs/db214ae34137ab29c7574f5fbe01bc4eaea6da7e/wordpress/stack.yml)
+You can also trigger a manual build via **Actions → Run workflow** with options to force a rebuild or skip release creation.
 
-## Te invito a visitar mi web
-Puedes ver nuevos eventos en [https://www.yonier.com/](https://www.yonier.com)
+## Versioning
+
+Image tags follow the Alpine package version of Samba (e.g., `4.19.6-r0`). The `latest` tag always points to the most recent build.
+
+```bash
+docker pull neytor/samba:latest
+docker pull neytor/samba:4.19.6-r0
+```
+
+---
+
+<div align="center">
+
+Visit my website at [yonier.com](https://www.yonier.com)
+
+</div>


### PR DESCRIPTION
## Changes

- **Workflow**: replaced Tools CI with the Samba multi-arch CI pipeline (version detection, native ARM/AMD64 builds, manifest merge, GitHub Release with changelog)
- **README**: rewritten in English with shields.io badges (Docker pulls, image size, GitHub stars, CI status), tech stack icons (Alpine, Docker, GitHub Actions, Samba), architecture table, and pipeline overview