### PR TITLE
feat: add wget and kubectl to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 FROM alpine
 
-LABEL maintainer Yonier Gomez
+LABEL maintainer="Yonier Gomez"
 
-RUN apk update && apk add --update --no-cache curl bind-tools zip iproute2 bash unzip python3 aws-cli\
+RUN apk update && apk add --update --no-cache \
+        curl \
+        wget \
+        bind-tools \
+        zip \
+        unzip \
+        iproute2 \
+        bash \
+        python3 \
+        aws-cli \
+        kubectl \
     && rm -rf /var/cache/apk/*


### PR DESCRIPTION
- Add `wget` and `kubectl` packages
- `ss` already available via `iproute2` (unchanged)
- `curl` and `aws-cli` already present (unchanged)
- Fix `LABEL` legacy key-value syntax warning