### PR TITLE
fix: correct README and workflow for neytor/tools

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Docker Multi-Arch CI - Samba
+name: Docker Multi-Arch CI - Tools
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       force_build:
-        description: 'Force build even if Samba version unchanged'
+        description: 'Force build even if Alpine version unchanged'
         required: false
         type: choice
         default: 'false'
@@ -26,21 +26,20 @@ permissions:
   contents: write
 
 jobs:
-  # ── Phase 1: detect whether a new Samba version is available ─────────────────
+  # ── Phase 1: detect whether a new Alpine version is available ────────────────
   check-version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.samba_version.outputs.version }}
+      version: ${{ steps.alpine_version.outputs.version }}
       should_build: ${{ steps.compare.outputs.should_build }}
 
     steps:
-      - name: Get latest Samba version from Alpine
-        id: samba_version
+      - name: Get latest Alpine version
+        id: alpine_version
         run: |
-          SAMBA_VERSION=$(docker run --rm alpine:latest sh -c \
-            "apk update > /dev/null 2>&1 && apk list samba 2>/dev/null | grep '^samba-' | head -1 | sed 's/samba-\([^ ]*\).*/\1/'")
-          echo "version=$SAMBA_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Samba version in Alpine: $SAMBA_VERSION"
+          ALPINE_VERSION=$(docker run --rm alpine:latest cat /etc/alpine-release)
+          echo "version=$ALPINE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Alpine version: $ALPINE_VERSION"
 
       - name: Get latest GitHub release tag
         id: get_release
@@ -58,7 +57,7 @@ jobs:
       - name: Decide whether to build
         id: compare
         run: |
-          CURRENT="v${{ steps.samba_version.outputs.version }}"
+          CURRENT="v${{ steps.alpine_version.outputs.version }}"
           LATEST="${{ steps.get_release.outputs.latest }}"
           FORCE="${{ github.event.inputs.force_build }}"
           if [[ "$CURRENT" != "$LATEST" || "$FORCE" == "true" ]]; then
@@ -103,7 +102,7 @@ jobs:
           file: ./Dockerfile
           platforms: ${{ matrix.platform }}
           push: true
-          outputs: type=image,name=neytor/samba,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=neytor/tools,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
         run: |
@@ -146,11 +145,11 @@ jobs:
         run: |
           VERSION="${{ needs.check-version.outputs.version }}"
           docker buildx imagetools create \
-            -t neytor/samba:latest \
-            -t neytor/samba:${VERSION} \
-            $(printf 'neytor/samba@sha256:%s ' $(ls /tmp/digests))
+            -t neytor/tools:latest \
+            -t neytor/tools:${VERSION} \
+            $(printf 'neytor/tools@sha256:%s ' $(ls /tmp/digests))
 
-  # ── Phase 4: GitHub Release with changelog ────────────────────────────────────
+  # ── Phase 4: GitHub Release ───────────────────────────────────────────────────
   release:
     needs: [check-version, build-and-push]
     if: needs.check-version.outputs.should_build == 'true' && github.event.inputs.skip_release != 'true'
@@ -166,21 +165,6 @@ jobs:
             --repo ${{ github.repository }} 2>/dev/null && echo "true" || echo "false")
           echo "exists=$EXISTS" >> "$GITHUB_OUTPUT"
 
-      - name: Get Samba release notes
-        id: changelog
-        run: |
-          VERSION="${{ needs.check-version.outputs.version }}"
-          SAMBA_BASE=$(echo "$VERSION" | sed 's/-r[0-9]*//')
-          URL="https://www.samba.org/samba/history/samba-${SAMBA_BASE}.html"
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
-          echo "base_version=$SAMBA_BASE" >> "$GITHUB_OUTPUT"
-          NOTES=$(curl -sf "$URL" 2>/dev/null | \
-            sed -n '/Changes since/,/<\/pre>/p' | \
-            sed 's/<[^>]*>//g' | \
-            sed '/^$/d' | \
-            head -60 || echo "No release notes found.")
-          echo "$NOTES" > /tmp/samba_changelog.txt
-
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'
         env:
@@ -188,17 +172,15 @@ jobs:
         run: |
           TAG="v${{ needs.check-version.outputs.version }}"
           VERSION="${{ needs.check-version.outputs.version }}"
-          CHANGELOG=$(cat /tmp/samba_changelog.txt)
-          NOTES_URL="${{ steps.changelog.outputs.url }}"
 
           cat > /tmp/release-notes.md << NOTES
-          ## Samba ${VERSION} on Alpine Linux
+          ## neytor/tools — Alpine Linux ${VERSION}
 
           ### Docker Images
 
           \`\`\`bash
-          docker pull neytor/samba:latest
-          docker pull neytor/samba:${VERSION}
+          docker pull neytor/tools:latest
+          docker pull neytor/tools:${VERSION}
           \`\`\`
 
           ### Supported Architectures
@@ -208,22 +190,28 @@ jobs:
           | linux/amd64 | \`latest\`, \`${VERSION}\` |
           | linux/arm64 | \`latest\`, \`${VERSION}\` |
 
-          ### Samba Changelog
+          ### Installed Tools
 
-          \`\`\`
-          ${CHANGELOG}
-          \`\`\`
-
-          > [Full release notes](${NOTES_URL})
+          | Package | Purpose |
+          |---|---|
+          | \`curl\` | HTTP requests & endpoint validation |
+          | \`wget\` | File downloads |
+          | \`bind-tools\` | DNS diagnostics (dig, nslookup, host) |
+          | \`iproute2\` | Network tooling (ss, ip) |
+          | \`aws-cli\` | AWS CLI v2 operations |
+          | \`kubectl\` | Kubernetes cluster management |
+          | \`python3\` | Scripting & automation |
+          | \`bash\` | Shell |
+          | \`zip\` / \`unzip\` | Archive handling |
 
           ### Quick Start
 
           \`\`\`bash
-          docker run -d --name samba -p 445:445 -v samba:/download neytor/samba
+          docker run --rm -it neytor/tools
           \`\`\`
           NOTES
 
           gh release create "$TAG" \
             --repo ${{ github.repository }} \
-            --title "Samba $VERSION" \
+            --title "Alpine ${VERSION}" \
             --notes-file /tmp/release-notes.md

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
 
-# 🗂️ neytor/samba
+# �️ neytor/tools
 
-**Lightweight Samba server on Alpine Linux — multi-architecture Docker image**
+**Lightweight troubleshooting & diagnostics container — multi-architecture Docker image**
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/neytor/samba?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/neytor/samba)
-[![Docker Image Size](https://img.shields.io/docker/image-size/neytor/samba/latest?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/neytor/samba)
+[![Docker Pulls](https://img.shields.io/docker/pulls/neytor/tools?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/neytor/tools)
+[![Docker Image Size](https://img.shields.io/docker/image-size/neytor/tools/latest?style=for-the-badge&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/neytor/tools)
 [![GitHub Stars](https://img.shields.io/github/stars/YonierGomez/tools?style=for-the-badge&logo=github&logoColor=white&color=181717)](https://github.com/YonierGomez/tools/stargazers)
 [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/YonierGomez/tools/docker-image.yml?style=for-the-badge&logo=githubactions&logoColor=white&label=CI)](https://github.com/YonierGomez/tools/actions)
 [![License](https://img.shields.io/github/license/YonierGomez/tools?style=for-the-badge&color=green)](LICENSE)
@@ -17,7 +17,8 @@
 ![Alpine Linux](https://img.shields.io/badge/Alpine_Linux-0D597F?style=for-the-badge&logo=alpine-linux&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white)
 ![GitHub Actions](https://img.shields.io/badge/GitHub_Actions-2088FF?style=for-the-badge&logo=github-actions&logoColor=white)
-![Samba](https://img.shields.io/badge/Samba-D32F2F?style=for-the-badge&logo=samba&logoColor=white)
+![AWS](https://img.shields.io/badge/AWS_CLI-FF9900?style=for-the-badge&logo=amazon-web-services&logoColor=white)
+![Kubernetes](https://img.shields.io/badge/kubectl-326CE5?style=for-the-badge&logo=kubernetes&logoColor=white)
 
 </div>
 
@@ -25,16 +26,12 @@
 
 ## Overview
 
-This image provides a minimal **Samba** (SMB/CIFS) server built on top of **Alpine Linux**. It is automatically rebuilt every Monday to track the latest Samba version available in the Alpine package registry, and published as a multi-architecture image.
+A minimal Alpine Linux container packed with the most common tools for **network diagnostics, endpoint validation, DNS resolution, AWS operations, and Kubernetes troubleshooting**. Rebuilt every Monday to stay in sync with the latest Alpine release.
 
 ## Quick Start
 
 ```bash
-docker run -d \
-  --name samba \
-  -p 445:445 \
-  -v samba:/download \
-  neytor/samba
+docker run --rm -it neytor/tools
 ```
 
 ## Usage
@@ -42,33 +39,41 @@ docker run -d \
 ### Docker CLI
 
 ```bash
-docker pull neytor/samba:latest
-docker run -d --name samba -p 445:445 -v samba:/download neytor/samba
+docker pull neytor/tools:latest
+docker run --rm -it neytor/tools
 ```
 
 ### Docker Compose
 
 ```yaml
 services:
-  samba:
-    container_name: samba
-    image: neytor/samba:latest
-    ports:
-      - "445:445"
-    volumes:
-      - samba:/download
-    restart: unless-stopped
-
-volumes:
-  samba:
+  tools:
+    container_name: tools
+    image: neytor/tools:latest
+    stdin_open: true
+    tty: true
 ```
+
+## Installed Packages
+
+| Package | Purpose |
+|---|---|
+| `curl` | HTTP requests & endpoint validation |
+| `wget` | File downloads |
+| `bind-tools` | DNS diagnostics (`dig`, `nslookup`, `host`) |
+| `iproute2` | Network tooling (`ss`, `ip`) |
+| `aws-cli` | AWS CLI v2 operations |
+| `kubectl` | Kubernetes cluster management |
+| `python3` | Scripting & automation |
+| `bash` | Shell |
+| `zip` / `unzip` | Archive handling |
 
 ## Supported Architectures
 
 | Architecture | Tag |
 |---|---|
-| `linux/amd64` | `latest`, `<version>` |
-| `linux/arm64` | `latest`, `<version>` |
+| `linux/amd64` | `latest`, `<alpine-version>` |
+| `linux/arm64` | `latest`, `<alpine-version>` |
 
 Both architectures are built natively (no QEMU emulation) using GitHub-hosted runners.
 
@@ -78,20 +83,20 @@ The workflow runs automatically every Monday at 08:00 UTC and follows four stage
 
 | Phase | Job | Description |
 |---|---|---|
-| 1 | `check-version` | Detects the latest Samba version from Alpine and compares with the last GitHub Release |
+| 1 | `check-version` | Detects the latest Alpine Linux version and compares with the last GitHub Release |
 | 2 | `build` | Builds per-arch images on native runners and pushes by digest |
 | 3 | `build-and-push` | Merges digests into a single multi-arch manifest |
-| 4 | `release` | Creates a GitHub Release with changelog fetched from samba.org |
+| 4 | `release` | Creates a GitHub Release tagged with the Alpine version |
 
 You can also trigger a manual build via **Actions → Run workflow** with options to force a rebuild or skip release creation.
 
 ## Versioning
 
-Image tags follow the Alpine package version of Samba (e.g., `4.19.6-r0`). The `latest` tag always points to the most recent build.
+Image tags follow the Alpine Linux version (e.g., `3.21.3`). The `latest` tag always points to the most recent build.
 
 ```bash
-docker pull neytor/samba:latest
-docker pull neytor/samba:4.19.6-r0
+docker pull neytor/tools:latest
+docker pull neytor/tools:3.21.3
 ```
 
 ---


### PR DESCRIPTION
- README: rewritten for `neytor/tools` (was incorrectly showing Samba content)\n- Workflow: version tracking now uses Alpine Linux version (`/etc/alpine-release`) instead of Samba package version\n- Release tags and Docker image tags now follow Alpine version (e.g. `3.21.3`)\n- Release notes now list installed tools instead of Samba changelog