### PR TITLE
fix: restore correct emoji in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# �️ neytor/tools
+# 🛠️ neytor/tools
 
 **Lightweight troubleshooting & diagnostics container — multi-architecture Docker image**
 


### PR DESCRIPTION
The 🛠️ emoji was stored with broken encoding and rendered as a replacement character on GitHub.